### PR TITLE
Beetroot fix

### DIFF
--- a/src/main/java/org/spongepowered/common/data/provider/block/state/CropsData.java
+++ b/src/main/java/org/spongepowered/common/data/provider/block/state/CropsData.java
@@ -40,9 +40,9 @@ public final class CropsData {
         registrator
                 .asImmutable(BlockState.class)
                     .create(Keys.GROWTH_STAGE)
-                        .constructValue((h, v) -> BoundedUtil.constructImmutableValueInteger(v, Keys.GROWTH_STAGE, CropBlock.AGE))
+                        .constructValue((h, v) -> BoundedUtil.constructImmutableValueInteger(v, Keys.GROWTH_STAGE, ((CropBlock) h.getBlock()).getAgeProperty()))
                         .get(h -> h.getValue(((CropBlock) h.getBlock()).getAgeProperty()))
-                        .set((h, v) -> BoundedUtil.setInteger(h, v, CropBlock.AGE))
+                        .set((h, v) -> BoundedUtil.setInteger(h, v, ((CropBlock) h.getBlock()).getAgeProperty()))
                         .supports(h -> h.getBlock() instanceof CropBlock);
     }
     // @formatter:on


### PR DESCRIPTION
Trying to set `Keys.GROWTH_STAGE` to beetroot seeds throws
`Cannot set property IntegerProperty{name=age, clazz=class java.lang.Integer, values=[0, 1, 2, 3, 4, 5, 6, 7]} as it does not exist in Block{minecraft:beetroots}` because it has different `AGE` property